### PR TITLE
Avoid crash when using yahoo.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Depends: ${misc:Depends}, ${python:Depends},
     python3-lxml,
     python3-dateutil,
     python3-requests,
+    python3-requests-oauthlib,
     geoclue-hostip,
     geoclue-ubuntu-geoip
 Description: Get weather information for your town with My-Weather-Indicator

--- a/src/myweatherindicator.py
+++ b/src/myweatherindicator.py
@@ -58,6 +58,7 @@ import weatherservice
 import worldweatheronlineapi
 import wopenweathermapapi
 import wundergroundapi
+import wyahooapi
 import machine_information
 from graph import Graph
 from comun import _


### PR DESCRIPTION
Without this change the indicator crashes after selecting yahoo.
(The only way out then is to modify the config `~/.config/my-weather-indicator/my-weather-indicator.conf`)

With this change yahoo is still blocked by an SSL error (at least on my system) but it is possible to change the service provider using the UI.