### PR TITLE
Add beaufort numbers to force description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ ENV/
 .ropeproject
 debian/files
 .mypy_cache/
+/.idea/

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ codefactor-badge: True
 
 Before you begin, ensure you have met the following requirements:
 
-* If you install it from PPA don't worry about, becouse all the requirements are included in the package
-* If you clone the repository, you need, at least, these dependecies,
+* If you install it from PPA don't worry about, because all the requirements are included in the package
+* If you clone the repository, you need, at least, these dependencies,
 
 ```
 gir1.2-gtk-3.0
@@ -86,7 +86,7 @@ When you start **<span id="project_title">My Weather Indicator</span>** it goes 
 
 In this screenshot, the language is Spanish, but, if there is no translation for your language, you will find the app in English.
 
-My-Weather-Indicator comes with a complete configuration dialog. You can set two locations for the wheater. In the mein location, you can set following options,
+My-Weather-Indicator comes with a complete configuration dialog. You can set two locations for the wheater. In the **Main location** tab, you can set following options,
 
 ![my-weather-indicator](./screenshots/screenshot_01.png)
 

--- a/src/weatherservice.py
+++ b/src/weatherservice.py
@@ -363,11 +363,11 @@ def change_velocity(valor, a):
             return _('Light breeze')
         elif valor <= 12:
             return _('Gentle breeze')
-        elif valor <= 17:
+        elif valor <= 18:
             return _('Moderate breeze')
         elif valor <= 24:
             return _('Fresh breeze')
-        elif valor <= 30:
+        elif valor <= 31:
             return _('Strong breeze')
         elif valor <= 38:
             return _('High wind')

--- a/src/weatherservice.py
+++ b/src/weatherservice.py
@@ -356,31 +356,31 @@ def change_velocity(valor, a):
             valor * units_u[a])), units_m[a])
     if a == 'Beaufort':
         if valor <= 1:
-            return _('Calm')
+            return "0 - " + _('Calm')
         elif valor <= 3:
-            return _('Light air')
+            return "1 - " + _('Light air')
         elif valor <= 7:
-            return _('Light breeze')
+            return "2 - " + _('Light breeze')
         elif valor <= 12:
-            return _('Gentle breeze')
+            return "3 - " + _('Gentle breeze')
         elif valor <= 18:
-            return _('Moderate breeze')
+            return "4 - " + _('Moderate breeze')
         elif valor <= 24:
-            return _('Fresh breeze')
+            return "5 - " + _('Fresh breeze')
         elif valor <= 31:
-            return _('Strong breeze')
+            return "6 - " + _('Strong breeze')
         elif valor <= 38:
-            return _('High wind')
+            return "7 - " + _('High wind')
         elif valor <= 46:
-            return _('Gale')
+            return "8 - " + _('Gale')
         elif valor <= 54:
-            return _('Strong gale')
+            return "9 - " + _('Strong gale')
         elif valor <= 63:
-            return _('Storm')
+            return "10 - " + _('Storm')
         elif valor <= 72:
-            return _('Violent storm')
+            return "11 - " + _('Violent storm')
         elif valor > 72:
-            return _('Hurricane')
+            return "12 - " + _('Hurricane')
     return ''
 
 


### PR DESCRIPTION
Add the number of the wind force to the Beaufort scale. This makes it easier to understand what the wind force is for people used to reading the numbers.

This is what it will look like in the main menu:

![menu](https://user-images.githubusercontent.com/3978757/232315219-1e3e98e1-9bf5-453a-9c4e-52a91f6f98e9.png)

And here's a screenshot from the forecast popup (in Dutch):

![forecast](https://user-images.githubusercontent.com/3978757/232315275-900f855d-973f-451a-af2b-69668390da05.png)

Background: I am from the Netherlands, and here the wind force is normally communicated as just the Beaufort number ([an example](https://nos.nl/weer)). I am not sure what's customary in other countries, but I did find [an example of the UK shipping forecast](https://www.metoffice.gov.uk/weather/specialist-forecasts/coast-and-sea/shipping-forecast) also mentioning just the numbers. So I guess it will be helpful for most people used to the Beaufort scale.

Additionally I fixed a few typos and two small errors in Beaufort scale boundaries in the wind force translation logic.