### PR TITLE
Ask Open Meteo for mph wind force numbers

### DIFF
--- a/src/wopenmeteoapi.py
+++ b/src/wopenmeteoapi.py
@@ -116,7 +116,8 @@ class OpenMeteoWeatherService(weatherservice.WeatherService):
                "winddirection_10m_dominant,shortwave_radiation_sum,"
                "uv_index_max,uv_index_clear_sky_max"
                "&hourly=relativehumidity_2m,apparent_temperature,"
-               "pressure_msl,dewpoint_2m,cloudcover,visibility,uv_index")
+               "pressure_msl,dewpoint_2m,cloudcover,visibility,uv_index"
+               "&windspeed_unit=mph")
         print(url)
         logger.info(url)
         data = self._do_get(url)
@@ -216,7 +217,8 @@ class OpenMeteoWeatherService(weatherservice.WeatherService):
                f"&longitude={self._longitude}&hourly=weathercode,"
                "temperature_2m,relativehumidity_2m,apparent_temperature,"
                "cloudcover,windspeed_10m,winddirection_10m,"
-               "precipitation_probability,visibility")
+               "precipitation_probability,visibility"
+               "&windspeed_unit=mph")
         logger.info(url)
         data = self._do_get(url)
         if data:


### PR DESCRIPTION
By default, api.open-meteo.com returns the wind speed in km/h instead of mph. Adding an explicit parameter forces the API to return mph, which results in correct wind speeds being displayed.

The wind speed calculation logic assumes the raw wind speed is always in mph, resulting in wind speeds 1.6 times too high. I noticed suspiciously high wind speeds for my home town when working on [this PR](https://github.com/atareao/my-weather-indicator/pull/108). I found out this was caused by the Open Meteo API returning km/h. I am not sure what the other supported weather APIs return, but maybe they could also use some additional testing.